### PR TITLE
Fix destroy `AboutCoordinator`.

### DIFF
--- a/iOSSampleApp/Scenarios/About/ViewControllers/AboutViewController.swift
+++ b/iOSSampleApp/Scenarios/About/ViewControllers/AboutViewController.swift
@@ -89,10 +89,10 @@ final class AboutViewController: UITableViewController, AboutStoryboardLodable {
         }).disposed(by: disposeBag)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        if navigationController?.viewControllers.index(of: self) == nil {
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        if navigationController == nil {
             delegate?.aboutViewControllerDismissed()
         }
     }


### PR DESCRIPTION
Great sample app helps me a lot.

I have found the timing destroy `AboutCoordinator` is not accurate.
When you pan back to trigger pop animation,  then cancel, will cause destroy `AboutCoordinator` immediately, as result, you can call `AboutCoordinator` related api  no more.