### PR TITLE
Use SwiftLint and SwiftGen as Xcode build plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ Sample iOS app written the way I write iOS apps because I cannot share the app I
 * Basic Dark mode support
 * Custom operator for simple UI code
 * Generated code to safely access assets
+* Xcode build plugins
 
 ## Getting started
 
 ### Prerequisites
 
-* XCode 14.2
-* [SwiftGen](https://github.com/SwiftGen/SwiftGen)
-* [SwifLint](https://github.com/realm/SwiftLint) (optional)
+* Xcode 14.2
 * [Fastlane](https://fastlane.tools/) (optional)
 
 ## Built with
@@ -51,6 +50,8 @@ Sample iOS app written the way I write iOS apps because I cannot share the app I
 - [SpecLeaks](leandromperez/specleaks) - Unit Tests Memory Leaks in Swift. Write readable tests for mem leaks easily with these Quick and Nimble extensions
 - [Quick](https://github.com/Quick/Quick) - The Swift (and Objective-C) testing framework
 - [Nimble](https://github.com/Quick/Nimble) - A Matcher Framework for Swift and Objective-C
+- [SwiftGen](https://github.com/SwiftGen/SwiftGen) - The Swift code generator for your assets, storyboards, Localizable.strings, … — Get rid of all String-based APIs
+- [SwifLint](https://github.com/realm/SwiftLint) - A tool to enforce Swift style and conventions
 
 ## Author
 

--- a/Sources/.swiftlint.yml
+++ b/Sources/.swiftlint.yml
@@ -14,6 +14,7 @@ disabled_rules:
     - file_length
     - function_body_length
     - nimble_operator
+    - blanket_disable_command
 
 analyzer_rules:
     - unused_import

--- a/Sources/Build-Phases/check-strings.sh
+++ b/Sources/Build-Phases/check-strings.sh
@@ -1,1 +1,0 @@
-${PROJECT_DIR}/../support/verify-string-files -master ${SRCROOT}/iOSSampleApp/Resources/Base.lproj/Localizable.strings

--- a/Sources/Build-Phases/generate-strings.sh
+++ b/Sources/Build-Phases/generate-strings.sh
@@ -1,6 +1,0 @@
-export PATH="$PATH:/opt/homebrew/bin"
-if which swiftgen >/dev/null; then
-swiftgen
-else
-echo "warning: SwiftGen not installed, download from https://github.com/SwiftGen/SwiftGen"
-fi

--- a/Sources/Build-Phases/lint.sh
+++ b/Sources/Build-Phases/lint.sh
@@ -1,6 +1,0 @@
-export PATH="$PATH:/opt/homebrew/bin"
-if which swiftlint >/dev/null; then
-swiftlint
-else
-echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
-fi

--- a/Sources/iOSSampleApp.xcodeproj/project.pbxproj
+++ b/Sources/iOSSampleApp.xcodeproj/project.pbxproj
@@ -160,7 +160,6 @@
 		F3AAA6251F86113A009653B7 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		F3ABC2B92285F6D00010BAF0 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		F3C2E59D24387A4E002A1449 /* generate-strings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "generate-strings.sh"; sourceTree = "<group>"; };
-		F3C2E59E24387A4E002A1449 /* lint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = lint.sh; sourceTree = "<group>"; };
 		F3C2E59F24387A4E002A1449 /* check-strings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "check-strings.sh"; sourceTree = "<group>"; };
 		F3C5F3512961BB1200257080 /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		F3C5F3532961BD8300257080 /* UIView+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layout.swift"; sourceTree = "<group>"; };
@@ -577,7 +576,6 @@
 			children = (
 				F3C2E59D24387A4E002A1449 /* generate-strings.sh */,
 				F3C2E59F24387A4E002A1449 /* check-strings.sh */,
-				F3C2E59E24387A4E002A1449 /* lint.sh */,
 			);
 			path = "Build-Phases";
 			sourceTree = "<group>";
@@ -682,7 +680,6 @@
 			buildPhases = (
 				F3FEEBB521628E2B00D1CF9E /* Generate strings */,
 				F3FEEBB621628FEA00D1CF9E /* Check strings */,
-				F32EAB1D1FCD517E007E4CED /* SwiftLint */,
 				F3A812B01F83740E00A09AAB /* Sources */,
 				F3A812B11F83740E00A09AAB /* Frameworks */,
 				F3A812B21F83740E00A09AAB /* Resources */,
@@ -690,6 +687,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				F32344CF29D814C000B1886D /* PBXTargetDependency */,
 			);
 			name = iOSSampleApp;
 			packageProductDependencies = (
@@ -714,8 +712,9 @@
 		F3A812AC1F83740E00A09AAB /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1230;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "Igor Kulman";
 				TargetAttributes = {
 					F3208A791F84E48100B57B0E = {
@@ -759,6 +758,7 @@
 				F300AE29244F76DC00F5E060 /* XCRemoteSwiftPackageReference "NotificationBanner" */,
 				F382F15624584B0A00861DDF /* XCRemoteSwiftPackageReference "specleaks" */,
 				F376423425A4689800C58CE5 /* XCRemoteSwiftPackageReference "Nuke" */,
+				F32344CD29D814B900B1886D /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = F3A812B51F83740E00A09AAB /* Products */;
 			projectDirPath = "";
@@ -802,21 +802,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F32EAB1D1FCD517E007E4CED /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/Build-Phases/lint.sh\n";
-		};
 		F3FEEBB521628E2B00D1CF9E /* Generate strings */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -943,6 +928,10 @@
 			isa = PBXTargetDependency;
 			target = F3A812B31F83740E00A09AAB /* iOSSampleApp */;
 			targetProxy = F3208A7F1F84E48100B57B0E /* PBXContainerItemProxy */;
+		};
+		F32344CF29D814C000B1886D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = F32344CE29D814C000B1886D /* SwiftLintPlugin */;
 		};
 		F35BD63C2065111F000AE4E8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1280,6 +1269,14 @@
 				version = 3.0.4;
 			};
 		};
+		F32344CD29D814B900B1886D /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = exactVersion;
+				version = 0.51.0;
+			};
+		};
 		F33474E5244F64220034B1C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -1361,6 +1358,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F300AE29244F76DC00F5E060 /* XCRemoteSwiftPackageReference "NotificationBanner" */;
 			productName = NotificationBannerSwift;
+		};
+		F32344CE29D814C000B1886D /* SwiftLintPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F32344CD29D814B900B1886D /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintPlugin";
 		};
 		F33474E6244F64220034B1C2 /* RxSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/iOSSampleApp.xcodeproj/project.pbxproj
+++ b/Sources/iOSSampleApp.xcodeproj/project.pbxproj
@@ -159,7 +159,6 @@
 		F3AAA6211F860E55009653B7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		F3AAA6251F86113A009653B7 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		F3ABC2B92285F6D00010BAF0 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
-		F3C2E59D24387A4E002A1449 /* generate-strings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "generate-strings.sh"; sourceTree = "<group>"; };
 		F3C2E59F24387A4E002A1449 /* check-strings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "check-strings.sh"; sourceTree = "<group>"; };
 		F3C5F3512961BB1200257080 /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		F3C5F3532961BD8300257080 /* UIView+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layout.swift"; sourceTree = "<group>"; };
@@ -574,7 +573,6 @@
 		F3C2E59C24387A4E002A1449 /* Build-Phases */ = {
 			isa = PBXGroup;
 			children = (
-				F3C2E59D24387A4E002A1449 /* generate-strings.sh */,
 				F3C2E59F24387A4E002A1449 /* check-strings.sh */,
 			);
 			path = "Build-Phases";
@@ -678,7 +676,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F3A812C61F83740E00A09AAB /* Build configuration list for PBXNativeTarget "iOSSampleApp" */;
 			buildPhases = (
-				F3FEEBB521628E2B00D1CF9E /* Generate strings */,
 				F3FEEBB621628FEA00D1CF9E /* Check strings */,
 				F3A812B01F83740E00A09AAB /* Sources */,
 				F3A812B11F83740E00A09AAB /* Frameworks */,
@@ -687,6 +684,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				F32344D629D816BD00B1886D /* PBXTargetDependency */,
 				F32344CF29D814C000B1886D /* PBXTargetDependency */,
 			);
 			name = iOSSampleApp;
@@ -759,6 +757,7 @@
 				F382F15624584B0A00861DDF /* XCRemoteSwiftPackageReference "specleaks" */,
 				F376423425A4689800C58CE5 /* XCRemoteSwiftPackageReference "Nuke" */,
 				F32344CD29D814B900B1886D /* XCRemoteSwiftPackageReference "SwiftLint" */,
+				F32344D429D816B500B1886D /* XCRemoteSwiftPackageReference "5am-swift-gen" */,
 			);
 			productRefGroup = F3A812B51F83740E00A09AAB /* Products */;
 			projectDirPath = "";
@@ -802,24 +801,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F3FEEBB521628E2B00D1CF9E /* Generate strings */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/iOSSampleApp/Resources/Base.lproj/Localizable.strings",
-				"$(SRCROOT)/iOSSampleApp/Assets.xcassets",
-			);
-			name = "Generate strings";
-			outputPaths = (
-				"$(SRCROOT)/iOSSampleApp/Resources/Strings.swift",
-				"$(SRCROOT)/iOSSampleApp/Resources/Assets.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/Build-Phases/generate-strings.sh\n";
-		};
 		F3FEEBB621628FEA00D1CF9E /* Check strings */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -932,6 +913,10 @@
 		F32344CF29D814C000B1886D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = F32344CE29D814C000B1886D /* SwiftLintPlugin */;
+		};
+		F32344D629D816BD00B1886D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = F32344D529D816BD00B1886D /* SwiftGenPlugin */;
 		};
 		F35BD63C2065111F000AE4E8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1277,6 +1262,14 @@
 				version = 0.51.0;
 			};
 		};
+		F32344D429D816B500B1886D /* XCRemoteSwiftPackageReference "5am-swift-gen" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/5amdotis/5am-swift-gen";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.0;
+			};
+		};
 		F33474E5244F64220034B1C2 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -1363,6 +1356,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F32344CD29D814B900B1886D /* XCRemoteSwiftPackageReference "SwiftLint" */;
 			productName = "plugin:SwiftLintPlugin";
+		};
+		F32344D529D816BD00B1886D /* SwiftGenPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F32344D429D816B500B1886D /* XCRemoteSwiftPackageReference "5am-swift-gen" */;
+			productName = "plugin:SwiftGenPlugin";
 		};
 		F33474E6244F64220034B1C2 /* RxSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/iOSSampleApp.xcodeproj/project.pbxproj
+++ b/Sources/iOSSampleApp.xcodeproj/project.pbxproj
@@ -159,7 +159,6 @@
 		F3AAA6211F860E55009653B7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		F3AAA6251F86113A009653B7 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		F3ABC2B92285F6D00010BAF0 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
-		F3C2E59F24387A4E002A1449 /* check-strings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "check-strings.sh"; sourceTree = "<group>"; };
 		F3C5F3512961BB1200257080 /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		F3C5F3532961BD8300257080 /* UIView+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layout.swift"; sourceTree = "<group>"; };
 		F3C5F3562961C60A00257080 /* LibraryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCell.swift; sourceTree = "<group>"; };
@@ -477,7 +476,6 @@
 		F3A812AB1F83740E00A09AAB = {
 			isa = PBXGroup;
 			children = (
-				F3C2E59C24387A4E002A1449 /* Build-Phases */,
 				F3A812B61F83740E00A09AAB /* iOSSampleApp */,
 				F3208A7B1F84E48100B57B0E /* iOSSampleAppTests */,
 				F35BD6372065111F000AE4E8 /* iOSSampleAppUITests */,
@@ -568,14 +566,6 @@
 				F3D9328121628CF000EA1E91 /* en */,
 			);
 			path = Resources;
-			sourceTree = "<group>";
-		};
-		F3C2E59C24387A4E002A1449 /* Build-Phases */ = {
-			isa = PBXGroup;
-			children = (
-				F3C2E59F24387A4E002A1449 /* check-strings.sh */,
-			);
-			path = "Build-Phases";
 			sourceTree = "<group>";
 		};
 		F3C5F3552961C60000257080 /* Cells */ = {
@@ -816,7 +806,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/Build-Phases/check-strings.sh\n";
+			shellScript = "${PROJECT_DIR}/../support/verify-string-files -master ${SRCROOT}/iOSSampleApp/Resources/Base.lproj/Localizable.strings\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Sources/iOSSampleApp.xcodeproj/xcshareddata/xcschemes/iOSSampleApp.xcscheme
+++ b/Sources/iOSSampleApp.xcodeproj/xcshareddata/xcschemes/iOSSampleApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/iOSSampleApp/Data/Licenses.plist
+++ b/Sources/iOSSampleApp/Data/Licenses.plist
@@ -60,7 +60,7 @@ THE SOFTWARE.
 	</dict>
 	<dict>
 		<key>license</key>
-		<string>Other</string>
+		<string>MIT License</string>
 		<key>text</key>
 		<string>**The MIT License**
 **Copyright © 2015 Krunoslav Zaher, Shai Mishali**
@@ -164,7 +164,7 @@ THE SOFTWARE.
 		<key>text</key>
 		<string>The MIT License (MIT)
 
-Copyright (c) 2015-2020 Alexander Grebenyuk
+Copyright (c) 2015-2023 Alexander Grebenyuk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/iOSSampleApp/Resources/Assets.swift
+++ b/Sources/iOSSampleApp/Resources/Assets.swift
@@ -8,6 +8,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")
@@ -65,6 +68,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -82,6 +92,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/iOSSampleApp/Resources/Strings.swift
+++ b/Sources/iOSSampleApp/Resources/Strings.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -11,41 +11,45 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// About
-  internal static let about = L10n.tr("Localizable", "about")
+  internal static let about = L10n.tr("Localizable", "about", fallback: "About")
   /// Add custom
-  internal static let addCustom = L10n.tr("Localizable", "add_custom")
+  internal static let addCustom = L10n.tr("Localizable", "add_custom", fallback: "Add custom")
   /// Add custom source
-  internal static let addCustomSource = L10n.tr("Localizable", "add_custom_source")
+  internal static let addCustomSource = L10n.tr("Localizable", "add_custom_source", fallback: "Add custom source")
   /// About author
-  internal static let author = L10n.tr("Localizable", "author")
+  internal static let author = L10n.tr("Localizable", "author", fallback: "About author")
   /// Back
-  internal static let back = L10n.tr("Localizable", "back")
+  internal static let back = L10n.tr("Localizable", "back", fallback: "Back")
   /// Invalid RSS feed URL
-  internal static let badUrl = L10n.tr("Localizable", "bad_url")
+  internal static let badUrl = L10n.tr("Localizable", "bad_url", fallback: "Invalid RSS feed URL")
   /// Author's blog
-  internal static let blog = L10n.tr("Localizable", "blog")
+  internal static let blog = L10n.tr("Localizable", "blog", fallback: "Author's blog")
   /// Done
-  internal static let done = L10n.tr("Localizable", "done")
+  internal static let done = L10n.tr("Localizable", "done", fallback: "Done")
   /// Feed
-  internal static let feed = L10n.tr("Localizable", "feed")
+  internal static let feed = L10n.tr("Localizable", "feed", fallback: "Feed")
   /// Used libraries
-  internal static let libraries = L10n.tr("Localizable", "libraries")
+  internal static let libraries = L10n.tr("Localizable", "libraries", fallback: "Used libraries")
   /// Logo URL
-  internal static let logoUrl = L10n.tr("Localizable", "logo_url")
+  internal static let logoUrl = L10n.tr("Localizable", "logo_url", fallback: "Logo URL")
   /// Network problem has occured
-  internal static let networkProblem = L10n.tr("Localizable", "network_problem")
+  internal static let networkProblem = L10n.tr("Localizable", "network_problem", fallback: "Network problem has occured")
   /// Optional
-  internal static let `optional` = L10n.tr("Localizable", "optional")
+  internal static let `optional` = L10n.tr("Localizable", "optional", fallback: "Optional")
   /// Pull to refresh
-  internal static let pullToRefresh = L10n.tr("Localizable", "pull_to_refresh")
+  internal static let pullToRefresh = L10n.tr("Localizable", "pull_to_refresh", fallback: "Pull to refresh")
   /// RSS URL
-  internal static let rssUrl = L10n.tr("Localizable", "rss_url")
-  /// Select source
-  internal static let selectSource = L10n.tr("Localizable", "select_source")
+  internal static let rssUrl = L10n.tr("Localizable", "rss_url", fallback: "RSS URL")
+  /// Localizable.strings
+  ///  iOSSampleApp
+  ///  
+  ///  Created by Igor Kulman on 03/10/2017.
+  ///  Copyright © 2017 Igor Kulman. All rights reserved.
+  internal static let selectSource = L10n.tr("Localizable", "select_source", fallback: "Select source")
   /// Title
-  internal static let title = L10n.tr("Localizable", "title")
+  internal static let title = L10n.tr("Localizable", "title", fallback: "Title")
   /// Url
-  internal static let url = L10n.tr("Localizable", "url")
+  internal static let url = L10n.tr("Localizable", "url", fallback: "Url")
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
@@ -53,8 +57,8 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = BundleToken.bundle.localizedString(forKey: key, value: nil, table: table)
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,16 +15,18 @@ default_platform(:ios)
 platform :ios do
   desc "Generate new localized screenshots"
   lane :screenshots do
-    capture_screenshots(project: "Sources/iOSSampleApp.xcodeproj", 
+    capture_screenshots(project: "Sources/iOSSampleApp.xcodeproj",
+                        xcargs: "-skipPackagePluginValidation",
                         scheme: "iOSSampleApp")
   end
 end
 
 desc "Run all unit tests"
 lane :tests do
-  run_tests(devices: ["iPhone 8"],
+  run_tests(devices: ["iPhone 14"],
             project: "Sources/iOSSampleApp.xcodeproj",
             skip_testing: "iOSSampleAppUITests",
+            xcargs: "-skipPackagePluginValidation",
             scheme: "iOSSampleApp")
 end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,42 +1,51 @@
 fastlane documentation
-================
+----
+
 # Installation
 
 Make sure you have the latest version of the Xcode command line tools installed:
 
-```
+```sh
 xcode-select --install
 ```
 
-Install _fastlane_ using
-```
-[sudo] gem install fastlane -NV
-```
-or alternatively using `brew install fastlane`
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
 
 # Available Actions
+
 ### tests
+
+```sh
+[bundle exec] fastlane tests
 ```
-fastlane tests
-```
+
 Run all unit tests
+
 ### update_licenses
+
+```sh
+[bundle exec] fastlane update_licenses
 ```
-fastlane update_licenses
-```
+
 Updates libraries licenses
 
 ----
 
+
 ## iOS
+
 ### ios screenshots
+
+```sh
+[bundle exec] fastlane ios screenshots
 ```
-fastlane ios screenshots
-```
+
 Generate new localized screenshots
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
-More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
Use SwiftLint and SwiftGen as Xcode build plugins instead of relying on having them installed on the machine.